### PR TITLE
feat: add hero carousel section with overlay text and responsive styles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -74,8 +74,67 @@
 </nav>
 <!-- ========================================== -->
 
+<!-- ================= HOME / HERO CAROUSEL ================= -->
+<section id="home">
+  <div id="heroCarousel" class="carousel slide" data-bs-ride="carousel" data-bs-interval="4000">
+
+    <!-- Indicators -->
+    <div class="carousel-indicators">
+      <button type="button" data-bs-target="#heroCarousel" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+      <button type="button" data-bs-target="#heroCarousel" data-bs-slide-to="1" aria-label="Slide 2"></button>
+      <button type="button" data-bs-target="#heroCarousel" data-bs-slide-to="2" aria-label="Slide 3"></button>
+    </div>
+
+    <!-- Slides (images only) -->
+    <div class="carousel-inner">
+      <div class="carousel-item active">
+        <img src="https://placehold.co/1920x800/3a3a3a/cccccc?text=Spa+Slide+1" class="d-block w-100 hero-img" alt="Spa Slide 1">
+      </div>
+      <div class="carousel-item">
+        <img src="https://placehold.co/1920x800/4a3a3a/cccccc?text=Spa+Slide+2" class="d-block w-100 hero-img" alt="Spa Slide 2">
+      </div>
+      <div class="carousel-item">
+        <img src="https://placehold.co/1920x800/3a4a3a/cccccc?text=Spa+Slide+3" class="d-block w-100 hero-img" alt="Spa Slide 3">
+      </div>
+    </div>
+
+    <!-- Controls -->
+    <button class="carousel-control-prev" type="button" data-bs-target="#heroCarousel" data-bs-slide="prev">
+      <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+      <span class="visually-hidden">Previous</span>
+    </button>
+    <button class="carousel-control-next" type="button" data-bs-target="#heroCarousel" data-bs-slide="next">
+      <span class="carousel-control-next-icon" aria-hidden="true"></span>
+      <span class="visually-hidden">Next</span>
+    </button>
+
+  </div>
+
+  <!-- Static overlay text (does NOT change with slides) -->
+  <div class="hero-overlay-text">
+    <p class="hero-welcome">Welcome to</p>
+    <h1 class="hero-title">SPA CENTER IN KOLKATA</h1>
+    <p class="hero-subtitle">Massage therapy center. Make an appointment in just a click!</p>
+    <a href="tel:+919999999999" class="btn btn-cta">CALL NOW</a>
+  </div>
+</section>
+<!-- ========================================================= -->
+
+<!-- Floating Contact Buttons -->
+<div class="floating-btns">
+  <a href="tel:+919999999999" class="float-btn phone-btn" aria-label="Call Us">
+    <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="currentColor" viewBox="0 0 16 16">
+      <path d="M3.654 1.328a.678.678 0 0 0-1.015-.063L1.605 2.3c-.483.484-.661 1.169-.45 1.77a17.6 17.6 0 0 0 4.168 6.608 17.6 17.6 0 0 0 6.608 4.168c.601.211 1.286.033 1.77-.45l1.034-1.034a.678.678 0 0 0-.063-1.015l-2.307-1.794a.68.68 0 0 0-.58-.122l-2.19.547a1.75 1.75 0 0 1-1.657-.459L5.482 8.062a1.75 1.75 0 0 1-.46-1.657l.548-2.19a.68.68 0 0 0-.122-.58zM1.884.511a1.745 1.745 0 0 1 2.612.163L6.29 2.98c.329.423.445.974.315 1.494l-.547 2.19a.68.68 0 0 0 .178.643l2.457 2.457a.68.68 0 0 0 .644.178l2.189-.547a1.75 1.75 0 0 1 1.494.315l2.306 1.794c.829.645.905 1.87.163 2.611l-1.034 1.034c-.74.74-1.846 1.065-2.877.702a18.6 18.6 0 0 1-7.01-4.42 18.6 18.6 0 0 1-4.42-7.009c-.362-1.03-.037-2.137.703-2.877z"/>
+    </svg>
+  </a>
+  <a href="https://wa.me/919999999999" target="_blank" class="float-btn whatsapp-btn" aria-label="WhatsApp">
+    <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" fill="currentColor" viewBox="0 0 16 16">
+      <path d="M13.601 2.326A7.85 7.85 0 0 0 7.994 0C3.627 0 .068 3.558.064 7.926c0 1.399.366 2.76 1.057 3.965L0 16l4.204-1.102a7.9 7.9 0 0 0 3.79.965h.004c4.368 0 7.926-3.558 7.93-7.93A7.9 7.9 0 0 0 13.6 2.326zM7.994 14.521a6.6 6.6 0 0 1-3.356-.92l-.24-.144-2.494.654.666-2.433-.156-.251a6.56 6.56 0 0 1-1.007-3.505c0-3.626 2.957-6.584 6.591-6.584a6.56 6.56 0 0 1 4.66 1.931 6.56 6.56 0 0 1 1.928 4.66c-.004 3.639-2.961 6.592-6.592 6.592m3.615-4.934c-.197-.099-1.17-.578-1.353-.646-.182-.065-.315-.099-.445.099-.133.197-.513.646-.627.775-.114.133-.232.148-.43.05-.197-.1-.836-.308-1.592-.985-.59-.525-.985-1.175-1.103-1.372-.114-.198-.011-.304.088-.403.087-.088.197-.232.296-.346.1-.114.133-.198.198-.33.065-.134.034-.248-.015-.347-.05-.099-.445-1.076-.612-1.47-.16-.389-.325-.335-.445-.34-.114-.007-.247-.007-.38-.007a.73.73 0 0 0-.529.247c-.182.198-.691.677-.691 1.654s.71 1.916.81 2.049c.098.133 1.394 2.132 3.383 2.992.47.205.84.326 1.129.418.475.152.904.129 1.246.08.38-.058 1.171-.48 1.338-.943.164-.464.164-.86.114-.943-.049-.084-.182-.133-.38-.232"/>
+    </svg>
+  </a>
+</div>
+
 <!-- Dummy sections for testing -->
-<section id="home" class="section">HOME</section>
 <section id="about" class="section">ABOUT</section>
 <section id="packages" class="section">PACKAGES</section>
 <section id="services" class="section">SERVICES</section>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -29,7 +29,128 @@
     color: #0d6efd !important;
 }
 
-/* Demo sections (for scroll testing only) */
+/* ============ HERO CAROUSEL ============ */
+#home {
+    position: relative;
+    overflow: hidden;
+}
+
+.hero-img {
+    height: 100vh;
+    object-fit: cover;
+    filter: brightness(0.55);
+}
+
+/* Static overlay on top of carousel */
+.hero-overlay-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 10;
+    text-align: center;
+    pointer-events: none;
+    width: 100%;
+    padding: 0 15%;
+}
+
+.hero-overlay-text .btn-cta {
+    pointer-events: auto;
+}
+
+.hero-welcome {
+    font-family: 'Georgia', serif;
+    font-style: italic;
+    font-size: 1.6rem;
+    color: #e8a87c;
+    margin-bottom: 5px;
+    letter-spacing: 2px;
+}
+
+.hero-title {
+    font-size: 3rem;
+    font-weight: 700;
+    letter-spacing: 4px;
+    color: #ffffff;
+    text-transform: uppercase;
+    margin-bottom: 15px;
+    text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.5);
+}
+
+.hero-subtitle {
+    font-size: 1rem;
+    color: #ddd;
+    margin-bottom: 25px;
+    letter-spacing: 1px;
+}
+
+.btn-cta {
+    background-color: #e8a87c;
+    color: #fff;
+    padding: 12px 35px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    border: none;
+    border-radius: 3px;
+    transition: background-color 0.3s ease;
+}
+
+.btn-cta:hover {
+    background-color: #d4956a;
+    color: #fff;
+}
+
+/* Carousel indicators */
+#heroCarousel .carousel-indicators button {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: rgba(255, 255, 255, 0.5);
+    border: none;
+}
+
+#heroCarousel .carousel-indicators button.active {
+    background-color: #e8a87c;
+}
+
+/* ============ FLOATING BUTTONS ============ */
+.floating-btns {
+    position: fixed;
+    bottom: 25px;
+    right: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    z-index: 1050;
+}
+
+.float-btn {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    text-decoration: none;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    transition: transform 0.3s ease;
+}
+
+.float-btn:hover {
+    transform: scale(1.1);
+    color: #fff;
+}
+
+.phone-btn {
+    background-color: #e8a87c;
+}
+
+.whatsapp-btn {
+    background-color: #25d366;
+}
+
+/* ============ DEMO SECTIONS ============ */
 .section {
     height: 100vh;
     display: flex;
@@ -47,5 +168,26 @@
 
     .nav-link {
         padding: 12px;
+    }
+
+    .hero-title {
+        font-size: 1.8rem;
+        letter-spacing: 2px;
+    }
+
+    .hero-welcome {
+        font-size: 1.2rem;
+    }
+
+    .hero-subtitle {
+        font-size: 0.9rem;
+    }
+
+    .hero-caption {
+        padding: 0 8%;
+    }
+
+    .hero-img {
+        height: 70vh;
     }
 }


### PR DESCRIPTION
This PR resolves the issue #3 
This pull request adds a visually engaging hero carousel section to the homepage, complete with overlay text and floating contact buttons for phone and WhatsApp. It also introduces new CSS styles to support the carousel, overlay, and floating buttons, as well as responsive adjustments for smaller screens.

*Demo:*
![carousel_demo](https://github.com/user-attachments/assets/535c4843-d004-4224-b949-601157e2ac87)


Homepage and hero carousel enhancements:

* Added a Bootstrap-powered hero carousel to the `#home` section, featuring three slides with placeholder images and carousel controls.
* Introduced a static overlay text on top of the carousel, including a welcome message, title, subtitle, and a prominent call-to-action button.

Contact accessibility improvements:

* Added floating contact buttons for phone and WhatsApp, positioned at the bottom-right corner of the page for easy access.

Styling and responsiveness:

* Implemented new CSS rules in `style.css` for the hero carousel, overlay text, call-to-action button, carousel indicators, and floating buttons.
* Added responsive CSS adjustments for the hero section and overlay text to ensure proper display on smaller screens.